### PR TITLE
no error hint when terminal lost focus

### DIFF
--- a/autoload/terminal.vim
+++ b/autoload/terminal.vim
@@ -184,7 +184,9 @@ function! terminal#partcb_out(id, msg)
   let msg = iconv(a:msg, 'char', &encoding)
   let msg = substitute(msg, "\r", "", "g")
   call s:append_part('__TERMINAL__', msg)
-  call job_status(b:job)
+  if exists('b:job')
+      call job_status(b:job)
+  endif
 endfunction
 
 function! terminal#exitcb(job, code)


### PR DESCRIPTION
to reproduce:

1. running a time consuming command that continuously output something
1. switch to other buffer